### PR TITLE
HOTFIX - Replaced CLFL with BTFL to restore functionality to preorder HELIO

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -567,7 +567,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         if ((CONFIG.flightControllerIdentifier === 'BTTR' && semver.gte(CONFIG.flightControllerVersion, "2.6.0")) ||
-            (CONFIG.flightControllerIdentifier === 'CLFL' && semver.gte(CONFIG.apiVersion, "1.31.0"))) {
+            (CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(CONFIG.apiVersion, "1.31.0"))) {
             serialRXtypes.push('JETIEXBUS');
         }
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -566,8 +566,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             serialRXtypes.push('IBUS');
         }
 
-        if ((CONFIG.flightControllerIdentifier === 'BTTR' && semver.gte(CONFIG.flightControllerVersion, "2.6.0")) ||
-            (CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(CONFIG.apiVersion, "1.31.0"))) {
+        if ((CONFIG.flightControllerIdentifier === 'BTTR' && semver.gte(CONFIG.apiVersion, "1.31.0")) ||
+            (CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(CONFIG.apiVersion, "1.31.0")) ||
+            (CONFIG.flightControllerIdentifier === 'CLFL' && semver.gte(CONFIG.apiVersion, "1.31.0"))) {
             serialRXtypes.push('JETIEXBUS');
         }
 

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -461,7 +461,7 @@ TABS.receiver.initModelPreview = function () {
     }
 
     var useOldRateCurve = false;
-    if (CONFIG.flightControllerIdentifier == 'CLFL' && semver.lt(CONFIG.apiVersion, '2.0.0')) {
+    if (CONFIG.flightControllerIdentifier == 'BTFL' && semver.lt(CONFIG.apiVersion, '2.0.0')) {
         useOldRateCurve = true;
     }
     if (CONFIG.flightControllerIdentifier == 'BTTR' && semver.lt(CONFIG.flightControllerVersion, '2.8.0')) {

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -461,6 +461,9 @@ TABS.receiver.initModelPreview = function () {
     }
 
     var useOldRateCurve = false;
+    if (CONFIG.flightControllerIdentifier == 'CLFL' && semver.lt(CONFIG.apiVersion, '2.0.0')) {
+        useOldRateCurve = true;
+    }
     if (CONFIG.flightControllerIdentifier == 'BTFL' && semver.lt(CONFIG.apiVersion, '2.0.0')) {
         useOldRateCurve = true;
     }


### PR DESCRIPTION
Restores functionality to the boards that were originally shipped by HELIO RC so people can connect to the configurator and flash latest.

