### PR TITLE
New "LEGACY_SA_SUPPORT" feature on the Configuraton tab

### DIFF
--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Filtratge notch dinamic de gyro"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Suport d'àudio intelligent llegat AKK i Mach2 VTX"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Funció de compatibilitat amb versions anteriors per AKK i Mach 2 VTX amb <strong>'incorrectament'</strong> implementació d'àudio intelligent."
+    },
     "featureFAILSAFE": {
         "message": "Activa Failsafe Stage 2"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -766,6 +766,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Dynamischer Gyro Notch Filter"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Legacy AKK und Mach2 VTX Smart Audio Unterstützung"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Abwärtskompatibilität für den AKK und Mach 2 VTX mit <strong>'nicht korrekt'</strong> Smart-Audio-Implementierung."
+    },
     "featureFAILSAFE": {
         "message": "Failsafe Stufe 2 aktivieren"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -825,6 +825,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Dynamic gyro notch filtering"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Legacy AKK and Mach2 VTX Smart Audio support"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Backward compatibility feature for AKK and Mach2 VTXes with <strong>'incorrect'</strong> Smart Audio implementation."
+    },
     "featureFAILSAFE": {
         "message": "Enable Failsafe Stage 2"
     },

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Filtro notch dinámico para el giro"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Compatibilidad con Legacy AKK y Mach2 VTX Smart Audio"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Compatibilidad con versiones anteriores para AKK y Mach 2 VTX con implementación de audio inteligente <strong>'incorrectamente'</strong>."
+    },
     "featureFAILSAFE": {
         "message": "Activar Etapa 2 del Modo de Seguridad"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Filtre dynamique Notch gyro"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Prise en charge de Legacy AKK et Mach2 VTX Smart Audio"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Fonction de rétrocompatibilité pour AKK et Mach 2 VTX avec implémentation audio <strong>'incorrectement'</strong>."
+    },
     "featureFAILSAFE": {
         "message": "Activer le Failsafe niveau 2"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Filtro di attenuazione dinamica giroscopio"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Supporto legacy AKK e Mach2 VTX Smart Audio"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "Funzionalità di retrocompatibilità per AKK e Mach 2 VTX con <strong>'erroneamente'</strong> implementazione di smart audio."
+    },
     "featureFAILSAFE": {
         "message": "Abilita Failsafe Stadio 2"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "다이나믹 자이로 노치 필터링"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "레거시 AKK 및 Mach2 VTX 스마트 오디오 지원"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "<strong>'잘못'</strong> 스마트 오디오 구현으로 AKK 및 Mach 2 VTX의 하위 호환성 기능."
+    },
     "featureFAILSAFE": {
         "message": "페일세이프 단계 2 활성"
     },

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -772,6 +772,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "Žiroskopa dinamiskā joslu ierobežojošā filtrēšana"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "Legacy AKK un Mach2 VTX Smart Audio atbalsts"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "AKK un Mach 2 VTX ar <strong>'nepareizi'</strong> smart audio ieviešanas funkciju ar atpakaļejošu datubāzi."
+    },
     "featureFAILSAFE": {
         "message": "Ieslēgt Failsafe posmu 2"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -775,6 +775,12 @@
     "featureDYNAMIC_FILTER": {
         "message": "动态陷波滤波"
     },
+    "featureLEGACY_SA_SUPPORT": {
+        "message": "传统AKK和Mach2 VTX智能音频支持"
+    },
+    "featureLEGACY_SA_SUPPORTTip": {
+        "message": "向AKK和Mach 2 VTX提供向后兼容功能，其中<strong>'不正确'</strong>智能音频实施。"
+    },
     "featureFAILSAFE": {
         "message": "启用二阶失控保护"
     },

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -95,6 +95,13 @@ var Features = function (config) {
                 {bit: 11, group: 'batteryCurrent', name: 'CURRENT_METER'}
             );
         }
+
+        if (semver.gte(CONFIG.apiVersion, "1.39.0"))
+        {
+            features.push(
+                { bit: 30, group: 'other', name: 'LEGACY_SA_SUPPORT', haveTip: true }
+            );
+        }
     }
 
     self._features = features;


### PR DESCRIPTION
- This PR should be accepted along with the [relevant Butterflight changes](https://github.com/ButterFlight/butterflight/pull/63) that refactors the existing vtx_akk_hack CLI command as a feature

- Translations are created with Google Translate, please feel free to suggest more accurate translations.

- The new "LEGACY_SA_SUPPORT" feaute is only visible on the Configuration tab if the flashed Butterflight firmware has an MSP protocol version 1.39.0 or above