### PR TITLE
Added gyro_stage_2_filter_type and Kalman Q & R values to the configurator UI

### DIFF
--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -1303,6 +1303,9 @@
     "tuningHelp": {
         "message": "<b>Consells d'ajustament<\/b><br \/><span class=\"message-negative\">IMPORTANT:<\/span> És important verificar la temperatura del motor durant els primers vols. Com més gran sigui el valor del filtre, millor volarà, però també tindràs més soroll als motors.<br>El valor predeterminat de 100Hz és òptim, però per a les configuracions de sorolloses pots provar de baixar el filtre Dterm a 50Hz i possiblement també el filtre del giròscop."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Filtres de la fase 2</b><br /><span class=\"message-negative\">IMPORTANT:</span> Només canvieu el filtre Etapa 2 si sap què està fent. Es necessita una àmplia investigació per comprendre certs filtres i la configuració requerida per a ells.<br>Per aquesta raó, aquesta configuració només està disponible si '<span class=\"message-negative\">Mode Expert</span>' està habilitat."
+    },
     "receiverThrottleMid": {
         "message": "Throttle MID"
     },
@@ -2380,17 +2383,38 @@
     "pidTuningFilterSettings": {
         "message": "Ajustaments de Filtre"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Configuració del filtre Kalman"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-Term Lowpass Filter"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Selecciona el filtre D-Term lowpass a fer servir. Per defecte es BIQUAD"
+        "message": "Selecciona el filtre D-Term lowpass a fer servir. Per defecte es PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Filtre d'etapa 2"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Etapa 2 Tipus de filtre a utilitzar. El valor predeterminat és FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D Term Lowpass Frequency [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D Term Lowpass Frequency [Hz] (0 significa disabled)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Kalman Q Coeficient"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Kalman Q Coeficient. La quantitat de confiança en la precisió de dades de gir (valor superior = més confiança i menys filtrat)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Kalman R Coeficient"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Kalman R Coeficient. La quantitat d'errors predicts en les dades de gir (valor superior = més errors predicts i més filtres)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Habilita D Term Notch Filter"

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -1300,6 +1300,9 @@
     "tuningHelp": {
         "message": "<b>Tuning tips<\/b><br \/><span class=\"message-negative\">Wichtig:<\/span>Es ist wichtig, bei den ersten Flügen die Motortemperatur im Auge zu behalten. Je höher die Filterwerte, desto besser könnte er fliegen, aber es wird auch mehr Rauschen in die Motoren gehen<br>Die Standarteinstellung 100Hz ist optimal, für problematische Setups könnte man jedoch richtung 50Hz Dterm Filter (und eventuell auch beim Gyro-Filter) gehen."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Stufe 2 Filter</b><br /><span class=\"message-negative\">Wichtig:</span> Bitte ändern Sie den Stufe 2 Filter nur, wenn Sie wissen, was Sie tun. Umfangreiche Nachforschungen sind erforderlich, um bestimmte Filter und die erforderliche Konfiguration für sie zu verstehen.<br>Aus diesem Grund ist diese Einstellung nur verfügbar, wenn '<span class=\"message-negative\">Expertenmodus</span>' aktiviert ist."
+    },
     "receiverThrottleMid": {
         "message": "Gas Mittelwert"
     },
@@ -2377,17 +2380,38 @@
     "pidTuningFilterSettings": {
         "message": "Filtereinstellungen"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Kalman Filtereinstellungen"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-Term Tiefpassfilter"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Wähle den D-Term lowpass Filter Typ aus. Standart ist BIQUAD"
+        "message": "Wähle den D-Term lowpass Filter Typ aus. Standart ist PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Stufe 2 Filter"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Stufe 2 Zu verwendender Filtertyp. Standard ist FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D-Term Tiefpass-Frequenz [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D-Term Tiefpass-Frequenz [Hz] (0 bedeutet 'aus')"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Kalman Q-Koeffizient"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Kalman Q-Koeffizient. Das Maß an Vertrauen in die Gyro-Datengenauigkeit (Höherer Wert = mehr Vertrauen und weniger Filterung)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Kalman R-Koeffizient"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Kalman R-Koeffizient. Die Anzahl der Fehler, die in Gyro-Daten vorhergesagt werden (höherer Wert = mehr Fehler vorhergesagt und mehr Filterung)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "D-Term Notchfilter einschalten"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1369,6 +1369,9 @@
     "tuningHelp": {
         "message": "<b>Tuning tips</b><br /><span class=\"message-negative\">IMPORTANT:</span> It is important to verify motor temperatures during first flights. The higher the filter value gets the better it may fly, but you also will get more noise into the motors. <br>Default value of 100Hz is optimal, but for noiser setups you can try lowering Dterm filter to 50Hz and possibly also the gyro filter."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Stage 2 Filters</b><br /><span class=\"message-negative\">IMPORTANT:</span> Please only change the Stage 2 Filter if you know what you are doing. Extensive research is needed to understand certain filters and the required configuration for them.<br>For this very reason, this setting is only available if '<span class=\"message-negative\">Expert mode</span>' is enabled."
+    },
     "receiverThrottleMid": {
         "message": "Throttle MID"
     },
@@ -2464,17 +2467,38 @@
     "pidTuningFilterSettings": {
         "message": "Filter Settings"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Kalman Filter Settings"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-Term Lowpass Filter"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Select D-Term lowpass filter type to use. Default is BIQUAD"
+        "message": "Select D-Term lowpass filter type to use. Default is PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Stage 2 Filter"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Stage 2 Filter type to use. Default is FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D Term Lowpass Frequency [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D Term Lowpass Frequency [Hz] (0 means disabled)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Kalman Q Coefficient"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Kalman filter Q Coefficient. The amount of trust in gyro data accuracy (Higher value = more trust and less filtering)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Kalman R Coefficient"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Kalman filter R Coefficient. The amount of errors predicted in gyro data (Higher value = more errors predicted and more filtering)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Enable D Term Notch Filter"

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -1306,6 +1306,9 @@
     "tuningHelp": {
         "message": "<b>Consejos para ajustar<\/b><br \/><span class=\"message-negative\">IMPORTANTE:<\/span> Es importante verificar las temperaturas de los motores durante los primeros vuelos. Cuanto más alto sea el valor del filtro puede que vuele mejor, pero más ruido llegará a los motores. <br>El valor por defecto de 100Hz es óptimo, pero para montajes más ruidosos puedes probar a bajar el filtro D Term a 50Hz y posiblemente también el filtro del giro."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Etapa 2 Filtros</b><br /><span class=\"message-negative\">IMPORTANTE:</span> Cambie el filtro Etapa 2 si sabe lo que está haciendo. Se necesita una amplia investigación para comprender ciertos filtros y la configuración requerida para ellos.<br>Por esta misma razón, esta configuración solo está disponible si se habilita '<span class=\"message-negative\">Modo experto</span>'."
+    },
     "receiverThrottleMid": {
         "message": "Acelerador MED"
     },
@@ -2383,17 +2386,38 @@
     "pidTuningFilterSettings": {
         "message": "Ajustes de Filtros"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Configuración del filtro de Kalman"
+    },
     "pidTuningDTermLowpassType": {
         "message": "Filtro Paso Bajo D Term"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Selecciona el tipo de filtro de paso bajo del D-Term a usar. Por defecto BIQUAD"
+        "message": "Selecciona el tipo de filtro de paso bajo del D-Term a usar. Por defecto PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Etapa 2 Filtro"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Etapa 2 Tipo de filtro a usar. El valor predeterminado es FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "Frecuencia Paso Bajo D Term [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "Frecuencia Paso Bajo D Term en Hz (0 significa desactivado)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Coeficiente de Kalman Q"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Coeficiente de Kalman Q. La cantidad de confianza en la precisión de datos del giroscopio (Mayor valor = más confianza y menos filtrado)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Coeficiente de Kalman R"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Coeficiente de Kalman R. La cantidad de errores predichos en datos de giro (valor más alto = más errores predichos y más filtrado)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Activar Filtro Notch D Term"

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -1306,6 +1306,9 @@
     "tuningHelp": {
         "message": "<b>Conseils tuning<\/b><br \/><span class=\"message-negative\">IMPORTANT:<\/span> Il est important de contrôler les températures moteurs au premier vol. Des valeurs de filtre élevées peuvent introduire du bruit et des échauffements moteurs <br>La valeur par défaut de 100 Hz est optimale, mais pour des setups noisy vous pouvez essayer de baisser le filtre Dterm à 50 Hz."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Filtres de l'étape 2</b><br /><span class=\"message-negative\">IMPORTANT:</span> Veuillez ne changer le filtre de niveau 2 que si vous savez ce que vous faites. Des recherches approfondies sont nécessaires pour comprendre certains filtres et la configuration requise pour ceux-ci.<br>Pour cette raison, ce paramètre n&#39;est disponible que si '<span class=\"message-negative\">Mode expert</span>' est activé."
+    },
     "receiverThrottleMid": {
         "message": "Throttle MID"
     },
@@ -2380,17 +2383,38 @@
     "pidTuningFilterSettings": {
         "message": "Réglages des Filtres"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Paramètres de filtre de Kalman"
+    },
     "pidTuningDTermLowpassType": {
         "message": "Filtre D-Term Lowpass"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Sélectionnez le type de filtre D-Term lowpass. La valeur par défaut est BIQUAD"
+        "message": "Sélectionnez le type de filtre D-Term lowpass. La valeur par défaut est PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Filtre de l'étape 2"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Étape 2 Type de filtre à utiliser. La valeur par défaut est FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": " Fréquence D Term Lowpass [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "Fréquence  D Term Lowpass [Hz] (0= désactivé)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Coefficient Q de Kalman"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Coefficient Q de Kalman. La quantité de confiance dans l'exactitude des données gyro (valeur plus élevée = plus de confiance et moins de filtrage)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Coefficient R de Kalman"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Coefficient R de Kalman. La quantité d'erreurs prédites dans les données gyro (valeur supérieure = plus d'erreurs prévues et plus de filtrage)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Activer le filtre D term Notch"

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -1306,6 +1306,9 @@
     "tuningHelp": {
         "message": "<b>Suggerimento per la messa a punto<\/b><br \/><span class=\"message-negative\">IMPORTANTE:<\/span> E' importante verificare la temperatura del motore durante il primo volo. Più alto è il valore del filtro, più dovrebbe volare meglio, ma avrai anche più rumore nei motori. <br>Il valore predefinito di 100Hz è ottimale, ma per setup più rumorosi puoi provare ad abbassare il filtro Dterm a 50Hz e possibilmente anche il filtro del giroscopio."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>Fase 2 Filtri</b><br /><span class=\"message-negative\">IMPORTANTE:</span> Si prega di cambiare il filtro Stage 2 solo se sai cosa stai facendo. Sono necessarie ricerche approfondite per comprendere determinati filtri e la configurazione richiesta per loro.<br>Per questo motivo, questa impostazione è disponibile solo se è abilitata la '<span class=\"message-negative\">Modalità esperto</span>'."
+    },
     "receiverThrottleMid": {
         "message": "Gas Medio"
     },
@@ -2383,17 +2386,38 @@
     "pidTuningFilterSettings": {
         "message": "Impostazioni filtro"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Impostazioni del filtro di Kalman"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-Term Lowpass Filter"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Selezionare il tipo di filtro D-Term lowpass da utilizzare. L'impostazione predefinita è BIQUAD"
+        "message": "Selezionare il tipo di filtro D-Term lowpass da utilizzare. L'impostazione predefinita è PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "Filtro Stage 2"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "Fase 2 Tipo di filtro da utilizzare. L&#39;impostazione predefinita è FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D-Term lowpass Frequenza [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D-Term lowpass Frequenza [Hz] (0 significa disabilitato)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Coefficiente di Kalman Q"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Coefficiente di Kalman Q. La quantità di fiducia nella precisione dei dati del giroscopio (valore più alto = più fiducia e meno filtri)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Coefficiente di Kalman R"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Coefficiente di Kalman R. La quantità di errori previsti nei dati del giroscopio (valore più alto = più errori previsti e più filtri)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Abilita filtro Notch D Term"

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -1306,6 +1306,9 @@
     "tuningHelp": {
         "message": "<b>튜닝 팁<\/b><br \/><span class=\"message-negative\">중요:<\/span> 첫 비행 중 모터 온도를 확인하는 것이 중요합니다. 필터 값이 높을수록 더 잘 날 수 있지만 모터에 더 많은 노이즈가 들리게 됩니다. <br> 기본값 100Hz가 최적이지만, 노이즈 설정을 위하여 D 항목 필터를 50Hz로 낮출 수 있으며, 자이로 필터를 낮추는 것 또한 가능합니다."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>2 단계 필터</b><br /><span class=\"message-negative\">중요:</span> 자신이하는 일을 아는 경우에만 2 단계 필터를 변경하십시오. 특정 필터 및 필요한 구성을 이해하려면 광범위한 연구가 필요합니다.<br>바로이 이유 때문에이 설정은 '<span class=\"message-negative\">전문가 모드</span>' 가 활성화 된 경우에만 사용할 수 있습니다."
+    },
     "receiverThrottleMid": {
         "message": "스로틀 중간값"
     },
@@ -2383,17 +2386,38 @@
     "pidTuningFilterSettings": {
         "message": "필터 설정"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "칼만 필터 설정"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-텀 저역통과 필터"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "사용할 D-텀 저역통과 필터 형태를 선택하세요. 기본은 BIQUAD입니다."
+        "message": "사용할 D-텀 저역통과 필터 형태를 선택하세요. 기본은 PT1입니다."
+    },
+    "pidTuningStage2FilterType": {
+        "message": "2 단계 필터"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "2 단계 사용할 필터 유형입니다. 기본값은 FAST KALMAN입니다."
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D 항목 저역통과 주파수 [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D 항목 저역통과 주파수 [Hz] (0은 비활성화를 의미)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Q 칼만 계수"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Q 칼만 계수. 자이로 데이터 정확도의 신뢰도 (높은 값 = 신뢰 증가 및 필터링 감소)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "R 칼만 계수"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "R 칼만 계수. 자이로 데이터에서 예측 된 오류의 양 (높은 값 = 더 많은 오류 예측 및 더 많은 필터링)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "D-텀 노치필터 활성"

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -1306,6 +1306,9 @@
     "tuningHelp": {
         "message": "<b>Ieregulēšanas ieteikumi <\/b><br \/><span class=\"message-negative\">SVARĪGI:<\/span> Ir svarīgi pārbaudīt motoru temperatūras pirmā lidojuma laikā. Jo lielākas filtru vērtības, jo labāk iespējams tas lidos, bet jūs iegūsiet lielāku trokšņu līmeni motoros. <br>Noklusētā vērtība 100Hz ir optimāla, bet pie trokšņainākām konstrukcijām, jūs varat mēģināt samazināt Dterm filtru uz 50Hz un iespējams arī žiroskopa filtru."
     },
+    "stage2FiltersHelp": {
+        "message": "<b>2. posma filtri</b><br /><span class=\"message-negative\">SVARĪGI:</span> Mainiet 2. posma filtru tikai tad, ja zināt, ko darāt. Ir vajadzīgi plašie pētījumi, lai izprastu noteiktus filtrus un nepieciešamo konfigurāciju tiem.<br>Šī iemesla dēļ šis iestatījums ir pieejams tikai tad, ja ir aktivizēts '<span class=\"message-negative\">Expert mode</span>'."
+    },
     "receiverThrottleMid": {
         "message": "Droseles vidus"
     },
@@ -2383,17 +2386,38 @@
     "pidTuningFilterSettings": {
         "message": "Filtra iestatījumi"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "Kalman filtra iestatījumi"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-Term zemfrekvenču filtrs"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "Izvēlieties kuru D-Term zemfrekvenču filtra tipu izmantot. Noklusējums ir BIQUAD"
+        "message": "Izvēlieties kuru D-Term zemfrekvenču filtra tipu izmantot. Noklusējums ir PT1"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "2. posma filtrs"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "2. posms, lai izmantotu filtra veidu. Noklusējums ir FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D Term zemfrekvenču frekvence [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D Term zemfrekvenču frekvence [Hz] (0 nozīmē izslēgts)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "Kalman Q koeficients"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "Kalman Q koeficients. Uzticības summa žiroskopa datu precizitātei (lielāka vērtība = lielāka uzticamība un mazāka filtrēšana)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "Kalman R koeficients"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "Kalman R koeficients. Giroskopiskajos datos paredzētā kļūdu summa (lielāka vērtība = ir paredzētas vairāk kļūdu un vairāk filtrēšanas)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "Ieslēgt D Term joslas filtru"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -1309,6 +1309,9 @@
     "tuningHelp": {
         "message": "<b> 调校技巧<\/b><br \/><span class=\"message-negative\">重要：<\/span>调校后的初次飞行需注意电机温度。滤波值越高，飞行效果可能越好，但也会导致更多的信号“噪音”进入电机。<br>100Hz 是默认较佳的数值，但对震动较严重的情况，你可以尝试把 Dterm 和 Gyro 滤波器降低到50Hz。"
     },
+    "stage2FiltersHelp": {
+        "message": "<b>第2阶段过滤器</b><br /><span class=\"message-negative\">重要：</span> 如果您知道自己在做什么，请只更改第2阶段过滤器。需要广泛的研究来了解某些过滤器及其所需的配置。<br>出于这个原因，只有在启用 '<span class=\"message-negative\">专家模式</span>' 时，此设置才可用。"
+    },
     "receiverThrottleMid": {
         "message": "油门中点"
     },
@@ -2386,17 +2389,38 @@
     "pidTuningFilterSettings": {
         "message": "滤波器设置"
     },
+    "pidTuningKalmanFilterSettings": {
+        "message": "卡尔曼滤波器设置"
+    },
     "pidTuningDTermLowpassType": {
         "message": "D-term 低通滤波器"
     },
     "pidTuningDTermLowpassTypeTip": {
-        "message": "选择 D-Term 低通滤波器类型，默认是BIQUAD。"
+        "message": "选择 D-Term 低通滤波器类型，默认是PT1。"
+    },
+    "pidTuningStage2FilterType": {
+        "message": "第2阶段过滤器"
+    },
+    "pidTuningStage2FilterTypeTip": {
+        "message": "阶段2使用的过滤器类型。默认为FAST KALMAN"
     },
     "pidTuningDTermLowpassFrequency": {
         "message": "D Term 低通频率 [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D Term 低通频率 [Hz] (0 表示禁用)"
+    },
+    "pidTuningKalmanFilterQ": {
+        "message": "卡尔曼Q系数"
+    },
+    "pidTuningKalmanFilterQHelp": {
+        "message": "卡尔曼Q系数. 陀螺仪数据准确性的信任量 (更高的值=更多的信任和更少的过滤)"
+    },
+    "pidTuningKalmanFilterR": {
+        "message": "卡尔曼R系数"
+    },
+    "pidTuningKalmanFilterRHelp": {
+        "message": "卡尔曼R系数. 在陀螺仪数据中预测的误差量 (更高的值=更多的误差预测和更多的过滤)"
     },
     "pidTuningDTermNotchEnable": {
         "message": "启用 D Term 陷波滤波器"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -53,6 +53,7 @@ var FAILSAFE_CONFIG;
 var RXFAIL_CONFIG;
 var PID_ADVANCED_CONFIG;
 var FILTER_CONFIG;
+var KALMAN_FILTER_CONFIG;
 var ADVANCED_TUNING;
 var SENSOR_CONFIG;
 var COPY_PROFILE;
@@ -343,6 +344,12 @@ var FC = {
             gyro_soft_notch_hz_2:       0,
             gyro_soft_notch_cutoff_2:   0,
             dterm_filter_type:          0,
+            gyro_stage2_filter_type:    0,
+        };
+
+        KALMAN_FILTER_CONFIG = {
+            gyro_filter_q:              0,
+            gyro_filter_r:              0,
         };
 
         ADVANCED_TUNING = {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -220,6 +220,7 @@ function startProcess() {
                         if (FEATURE_CONFIG) {
                             updateTabList(FEATURE_CONFIG.features);
                         }
+                        updateExpertModeOnlyUIElements();
 
                     }).change();
                 });
@@ -401,6 +402,7 @@ function startProcess() {
             if (FEATURE_CONFIG) {
                 updateTabList(FEATURE_CONFIG.features);
             }
+            updateExpertModeOnlyUIElements();
         }).change();
     });
 };
@@ -552,6 +554,11 @@ function updateTabList(features) {
     } else {
         $('#tabs ul.mode-connected li.tab_power').hide();
     }
+}
+
+function updateExpertModeOnlyUIElements() {
+    $('.stage2FilterType').toggle(isExpertModeEnabled());
+    $('.stage2FilterWarning').toggle(isExpertModeEnabled());
 }
 
 function zeroPad(value, width) {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -146,6 +146,10 @@ var MSPCodes = {
     MSP_SET_GPS_CONFIG:             223,
     MSP_SET_COMPASS_CONFIG:         224,
 
+    //Fast Kalman Q & R
+    MSP_FAST_KALMAN:                225,
+    MSP_SET_FAST_KALMAN:            226,
+
     MSP_SET_ACC_TRIM:               239,
     MSP_ACC_TRIM:                   240,
     MSP_SERVO_MIX_RULES:            241,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -837,7 +837,14 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         FILTER_CONFIG.dterm_filter_type = data.readU8();
                     }
+                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                        FILTER_CONFIG.gyro_stage2_filter_type = data.readU8();
+                    }
                 }
+                break;
+            case MSPCodes.MSP_FAST_KALMAN:
+                KALMAN_FILTER_CONFIG.gyro_filter_q = data.readU16();
+                KALMAN_FILTER_CONFIG.gyro_filter_r = data.readU16();
                 break;
             case MSPCodes.MSP_SET_PID_ADVANCED:
                 console.log("Advanced PID settings saved");
@@ -1469,7 +1476,14 @@ MspHelper.prototype.crunch = function(code) {
                 if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                     buffer.push8(FILTER_CONFIG.dterm_filter_type);
                 }
+                if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                    buffer.push8(FILTER_CONFIG.gyro_stage2_filter_type);
+                }
             }
+            break;
+        case MSPCodes.MSP_SET_FAST_KALMAN:
+            buffer.push16(KALMAN_FILTER_CONFIG.gyro_filter_q);
+            buffer.push16(KALMAN_FILTER_CONFIG.gyro_filter_r);
             break;
         case MSPCodes.MSP_SET_PID_ADVANCED:
             if (semver.gte(CONFIG.apiVersion, "1.20.0")) {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -27,17 +27,26 @@ TABS.pid_tuning.initialize = function (callback) {
         return MSP.promise(MSPCodes.MSP_PID);
     }).then(function() {
         if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-          return MSP.promise(MSPCodes.MSP_PID_ADVANCED);
+            return MSP.promise(MSPCodes.MSP_PID_ADVANCED);
         }
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_RC_TUNING);
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_FILTER_CONFIG);
+    }).then(function () {
+        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+            return MSP.promise(MSPCodes.MSP_FAST_KALMAN);
+        }
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_RC_DEADBAND);
     }).then(function() {
         $('#content').load("./tabs/pid_tuning.html", process_html);
-    });
+        });
+
+    function isKalmanFilterSelected() {
+        var selectedStage2Filter = $('.profile select[name="stage2FilterType"]').val();
+        return selectedStage2Filter == 2 || selectedStage2Filter == 3;
+    }
 
     function pid_and_rc_to_form() {
         self.setProfile();
@@ -268,6 +277,23 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.antigravity').hide();
         }
 
+        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+            $('.profile select[name="stage2FilterType"]').change(function () {
+                $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
+            });
+            $('.profile select[name="stage2FilterType"]').val(FILTER_CONFIG.gyro_stage2_filter_type);
+
+            $('.pid_filter input[name="kalmanQCoefficient"]').val(KALMAN_FILTER_CONFIG.gyro_filter_q);
+            $('.pid_filter input[name="kalmanRCoefficient"]').val(KALMAN_FILTER_CONFIG.gyro_filter_r);
+
+            updateExpertModeOnlyUIElements();
+            $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
+        } else {
+            $('.stage2FilterWarning').hide();
+            $('.stage2FilterType').hide();
+            $('.kalmanFilterSettingsPanel').hide();
+        }
+
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
             var hz = FILTER_CONFIG.gyro_soft_notch_hz_1 > 0 ? FILTER_CONFIG.gyro_soft_notch_hz_1 : DEFAULT.gyro_soft_notch_hz_1;
@@ -410,6 +436,14 @@ TABS.pid_tuning.initialize = function (callback) {
             FILTER_CONFIG.dterm_filter_type = $('.profile select[name="dtermFilterType"]').val();
             ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
             ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
+        }
+
+        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+            if (isExpertModeEnabled()) {
+                FILTER_CONFIG.gyro_stage2_filter_type = $('.profile select[name="stage2FilterType"]').val();
+            }
+            KALMAN_FILTER_CONFIG.gyro_filter_q = parseInt($('.pid_filter input[name="kalmanQCoefficient"]').val());
+            KALMAN_FILTER_CONFIG.gyro_filter_r = parseInt($('.pid_filter input[name="kalmanRCoefficient"]').val());
         }
     }
 
@@ -1021,6 +1055,10 @@ TABS.pid_tuning.initialize = function (callback) {
               return MSP.promise(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED));
             }).then(function () {
                 return MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
+            }).then(function () {
+                if (semver.gte(CONFIG.apiVersion, "1.40.0") && isKalmanFilterSelected()) {
+                    return MSP.promise(MSPCodes.MSP_SET_FAST_KALMAN, mspHelper.crunch(MSPCodes.MSP_SET_FAST_KALMAN));
+                }
             }).then(function () {
                 return MSP.promise(MSPCodes.MSP_SET_RC_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_RC_TUNING));
             }).then(function () {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -456,10 +456,13 @@
                     <div class="note_spacer">
                         <p i18n="tuningHelp"></p>
                     </div>
+                    <div class="note_spacer stage2FilterWarning">
+                        <p i18n="stage2FiltersHelp"></p>
+                    </div>
                 </div>
 
-                <div class="dtermfiltertype cf_column twothird">
-                    <div class="profile single-field" style="width:200px; margin-bottom: 0px;">
+                <div class="cf_column twothird">
+                    <div class="dtermfiltertype profile single-field" style="width:200px; margin-bottom: 0px;">
                         <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassTypeTip" style="margin-top: 5px;"></div>
                         <div class="head" i18n="pidTuningDTermLowpassType"></div>
                         <div class="bottomarea">
@@ -467,6 +470,18 @@
                                 <option value="0" class="PT1">PT1</option>
                                 <option value="1" class="BIQUAD">BIQUAD</option>
                                 <option value="2" class="FIR">FIR</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="stage2FilterType profile single-field" style="width:200px; margin-bottom: 0px;">
+                        <div class="helpicon cf_tip" i18n_title="pidTuningStage2FilterTypeTip" style="margin-top: 5px;"></div>
+                        <div class="head" i18n="pidTuningStage2FilterType"></div>
+                        <div class="bottomarea">
+                            <select name="stage2FilterType">
+                                <option value="0" class="NONE">NONE</option>
+                                <option value="1" class="BIQUAD_RC_FIR2">BIQUAD RC FIR2</option>
+                                <option value="2" class="FAST_KALMAN">FAST KALMAN (DEFAULT)</option>
+                                <option value="3" class="FIXED_K_KALMAN">FIXED K KALMAN</option>
                             </select>
                         </div>
                     </div>
@@ -639,6 +654,41 @@
                                             <span i18n="pidTuningYawLowpassFrequency"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningYawLowpassFrequencyHelp"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="gui_box grey topspacer pid_filter kalmanFilterSettingsPanel">
+                        <table class="pid_titlebar new_rates">
+                            <tr>
+                                <th i18n="pidTuningKalmanFilterSettings"></th>
+                            </tr>
+                        </table>
+                        <table>
+                            <tr>
+                                <td>
+                                    <input type="number" name="kalmanQCoefficient" step="1" min="20" max="48000"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningKalmanFilterQ"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterQHelp"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter">
+                                <td>
+                                    <input type="number" name="kalmanRCoefficient" step="1" min="0" max="16000"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningKalmanFilterR"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterRHelp"></div>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
- Added Stage 2 Filter setting [dropdown] to PID Tuning ->Filters tab (Expert mode only)
- Added warning message for Stage 2 Filter usage (Expert mode only)
- Added Kalman Q & R values setting panel (Only when FAST KALMAN or FIXED K KALMAN Stage 2 Filter is used)
- Added relevant help for new config values
- Added translations for all supported languages
- New config values are only available from MSP protocol version 1.40.0