### PR TITLE
Move Firmware Flasher tab's progress bar to the bottom toolbar

### DIFF
--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -1,5 +1,5 @@
 .tab-firmware_flasher .info {
-    margin: 10px 0 0 0;
+    margin: 3px 0 0 10px;
     position: relative;
 }
 
@@ -26,7 +26,6 @@
 }
 
 .tab-firmware_flasher .info {
-    float: left;
     width: 100%;
 }
 
@@ -256,6 +255,23 @@
 .tab-firmware_flasher .buttons .back {
     float: right;
     margin: 0;
+}
+
+.content_toolbar {
+    display:flex;
+}
+
+.content_toolbar .progress_wrapper {
+    flex: 1 1 auto;
+    margin-right: 50px;
+}
+
+.content_toolbar .button_wrapper {
+    flex: 0 0 auto;
+}
+
+.btn {
+    float: right;
 }
 
 .btn .disabled {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -107,21 +107,25 @@
                 <p i18n="firmwareFlasherRecoveryText"></p>
             </div>
         </div>
-            
-        <div class="info"><a name="progressbar"></a>
-            <progress class="progress" value="0" min="0" max="100"></progress>
-            <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>
-        </div>
     </div>
     <div class="content_toolbar">
-        <div class="btn">
-            <a class="load_file" i18n="firmwareFlasherButtonLoadLocal"></a>
+        <div class="progress_wrapper">
+            <div class="info">
+                <a name="progressbar"></a>
+                <progress class="progress" value="0" min="0" max="100"></progress>
+                <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>
+            </div>
         </div>
-        <div class="btn">
-            <a class="load_remote_file disabled" i18n="firmwareFlasherButtonLoadOnline"></a>
-        </div>
-        <div class="btn">
-            <a class="flash_firmware disabled" i18n="firmwareFlasherFlashFirmware"></a>
+        <div class="button_wrapper">
+            <div class="btn">
+                <a class="load_file" i18n="firmwareFlasherButtonLoadLocal"></a>
+            </div>
+            <div class="btn">
+                <a class="load_remote_file disabled" i18n="firmwareFlasherButtonLoadOnline"></a>
+            </div>
+            <div class="btn">
+                <a class="flash_firmware disabled" i18n="firmwareFlasherFlashFirmware"></a>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Make the progress bar always visible without scrolling on the bottom toolbar of the tab
- Refactored to use flex container to support different length texts for buttons (for translations)

Suggested by: @orneryd 👍 