### PR TITLE
Fix UI defects on Configuration and Filters tab

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -557,8 +557,10 @@ function updateTabList(features) {
 }
 
 function updateExpertModeOnlyUIElements() {
-    $('.stage2FilterType').toggle(isExpertModeEnabled());
-    $('.stage2FilterWarning').toggle(isExpertModeEnabled());
+    if (CONFIG.boardIdentifier !== "HESP") {
+        $('.stage2FilterType').toggle(isExpertModeEnabled());
+        $('.stage2FilterWarning').toggle(isExpertModeEnabled());
+    }
 }
 
 function zeroPad(value, width) {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -659,9 +659,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="board_align_pitch"]').val(BOARD_ALIGNMENT_CONFIG.pitch);
         $('input[name="board_align_yaw"]').val(BOARD_ALIGNMENT_CONFIG.yaw);
 
-        if (CONFIG.boardIdentifier != "HESP") {
-            // fill board alignment
-            $('#use_advanced_board_alignment').hide();
+        if (CONFIG.boardIdentifier !== "HESP") {
+            $('.use_advanced_board_alignment_container').hide();
         } else {
             function toggleAdv(){
                 var checked = $(this).is(':checked');
@@ -677,7 +676,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 }
             }
             $('#use_advanced_board_alignment').on('change', toggleAdv);
-            $('#use_advanced_board_alignment').show();
+            $('.use_advanced_board_alignment_container').show();
             if (BOARD_ALIGNMENT_CONFIG.roll || BOARD_ALIGNMENT_CONFIG.pitch || BOARD_ALIGNMENT_CONFIG.yaw){
                 $('#use_advanced_board_alignment').prop('checked', true);
                 setTimeout(toggleAdv.bind($('#use_advanced_board_alignment')),10);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -283,39 +283,38 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dtermfiltertype').hide();
             $('.antigravity').hide();
         }
-        if (CONFIG.boardIdentifier != "HESP") {
-            $('.dtermfiltertype').hide();            
-        }
 
         if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-            $('.profile select[name="stage2FilterType"]').change(function () {
-                $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
-            });
             $('.profile select[name="stage2FilterType"]').val(FILTER_CONFIG.gyro_stage2_filter_type);
-            if (CONFIG.boardIdentifier !== "HESP"){
+
+            if (CONFIG.boardIdentifier !== "HESP") {
+                $('.profile select[name="stage2FilterType"]').change(function () {
+                    $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
+                });
                 $('.pid_filter input[name="kalmanQCoefficient"]').val(KALMAN_FILTER_CONFIG.gyro_filter_q);
                 $('.pid_filter input[name="kalmanRCoefficient"]').val(KALMAN_FILTER_CONFIG.gyro_filter_r);
+                $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
             } else {
                 $('#imuf_roll_q').val(IMUF_FILTER_CONFIG.imuf_roll_q);
                 $('#imuf_pitch_q').val(IMUF_FILTER_CONFIG.imuf_pitch_q);
                 $('#imuf_yaw_q').val(IMUF_FILTER_CONFIG.imuf_yaw_q);
+
+                //Only show HELIO SPRING compatible settings
+                $('.dtermfiltertype').hide();
+                $('.stage2FilterWarning').hide();
+                $('.stage2FilterType').hide();
+                $('#profileIndependentFilterSettings').hide();
+                $('#pidTuningYawLowpassFrequency').hide();
+                $('.kalmanFilterSettingsPanel').hide();
+                $('#filterTuningHelp').hide();
+                $('#imufFilterSettingsPanel').show();
             }
             updateExpertModeOnlyUIElements();
-            $('.kalmanFilterSettingsPanel').toggle(isKalmanFilterSelected());
         } else {
             $('.stage2FilterWarning').hide();
             $('.stage2FilterType').hide();
             $('.kalmanFilterSettingsPanel').hide();
-        }
-        if (CONFIG.boardIdentifier == "HESP") {
-            $('.dtermfiltertype').hide();
-            $('.stage2FilterWarning').hide();
-            $('.stage2FilterType').hide();
-            $('#profileIndependentFilterSettings').hide();  
-            $('#pidTuningYawLowpassFrequency').hide();  
-            $('.kalmanFilterSettingsPanel').toggle(false);
-            $('#filterTuningHelp').hide();
-            $('#imufFilterSettingsPanel').show();
+            $('#imufFilterSettingsPanel').hide();
         }
 
         $('input[id="gyroNotch1Enabled"]').change(function() {

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -247,7 +247,7 @@
                             </div>
                             <div class="spacer_box">    
                                 <div class="sensoralignment">
-                                    <div style="display: inline-block;" class="use_advanced_board_alignment">
+                                    <div style="display: inline-block;" class="use_advanced_board_alignment_container">
                                     <label style="margin: 0;">
                                         <input id="use_advanced_board_alignment" class="togglesmall" type="checkbox"/>
                                         <span class="use_advanced_board_alignment_label" i18n="advancedBoardAlignment"></span>


### PR DESCRIPTION
- Fixed "Advanced" switch showing at board alignment for non Helio Spring boards without a function (renamed the container div for the switch and used the class to hide it)
- Fixed "Expert Mode" switch related issues on Filters tab when using a Helio Spring board
- Fixed D term filter type not showing up
- Moved showing Helio Spring specific settings on the Filter tab under 1.40.0 MSP protocol version restriction to prevent settings showing up for older firmware versions with incompatible MSP protocol versions